### PR TITLE
Update OnlineUpdateUASparser.java

### DIFF
--- a/src/main/java/cz/mallat/uasparser/OnlineUpdateUASparser.java
+++ b/src/main/java/cz/mallat/uasparser/OnlineUpdateUASparser.java
@@ -61,10 +61,11 @@ public class OnlineUpdateUASparser extends UASparser {
 	 */
 	protected String getVersionFromServer() throws IOException {
 		URL url = new URL(VERSION_CHECK_URL);
+		InputStream is = null;
 		try{
-			InputStream is = url.openStream();
+			is = url.openStream();
 		} catch (ConnectException e) {
-                	return '0';
+                	return "0"; //not sure about this
 		}
 		
 		try {


### PR DESCRIPTION
Fixes 2 errors:
1) The variable "is" which is defined in a try/catch block is out of scope when it is referenced on line 73.
2) on line 68, type char is the wrong type to return for the function, which returns a String.

Here's a patch:

63a64

> ```
>   InputStream is = null;
> ```
> 
> 65c66
> ## <           InputStream is = url.openStream();
> 
> ```
>        is = url.openStream();
> ```
> 
> 67c68
> ## <                   return '0';
> 
> ```
>               return "0"; //???
> ```
